### PR TITLE
Added support for use with `no_std`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ script: |
       cargo +$RUST_TOOLCHAIN test --no-default-features
     ); done
 
-    cargo +nightly test --no-default-features
-    cargo +nightly test --no-default-features --all-features
-
     cargo +$FMT_VERSION fmt -- --check
     cargo +$CLIPPY_VERSION clippy --all-targets --all-features -- -D warnings
     cargo +$DOCS_RS_VERSION doc --no-deps --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,14 @@ before_script: |
 script: |
   ( set -o errexit;set -o pipefail; set -o xtrace;set -o nounset;
     for RUST_TOOLCHAIN in $RUST_TOOLCHAINS; do (
+      cargo +$RUST_TOOLCHAIN test
       cargo +$RUST_TOOLCHAIN test --all-features
+      cargo +$RUST_TOOLCHAIN test --no-default-features
     ); done
+
+    cargo +nightly test --no-default-features
+    cargo +nightly test --no-default-features --all-features
+
     cargo +$FMT_VERSION fmt -- --check
     cargo +$CLIPPY_VERSION clippy --all-targets --all-features -- -D warnings
     cargo +$DOCS_RS_VERSION doc --no-deps --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ readme = "README.md"
 [badges]
 travis-ci = { repository = "alecmocatta/replace_with" }
 maintenance = { status = "actively-developed" }
+
+[features]
+default = ["std"]
+std = []
+nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ maintenance = { status = "actively-developed" }
 default = ["std"]
 std = []
 nightly = []
+panic_abort = []

--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ The [`replace_with_or_abort()`](https://docs.rs/replace_with/0.1.2/replace_with/
 
 As such `replace_with` will by default call [`core::intrinsics::abort()`](https://doc.rust-lang.org/core/intrinsics/fn.abort.html) instead, which in turn requires nightly Rust.
 
+Not everything is lost for stable `no_std` though, `replace_with` has one more trick up its sleeve:
+
+### panic = "abort"
+
+If you define [`panic = abort`](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/aborting-on-panic.html) in the `[profile]` section of your crate's `Cargo.toml` …
+
+```toml
+// Cargo.toml
+
+[profile.debug]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+```
+
+… and add the `"panic_abort"` feature to `replace_with` in the `dependencies` section of your crate's `Cargo.toml` …
+
+```toml
+// Cargo.toml
+
+[dependencies.replace_with]
+features = ["panic_abort"]
+...
+```
+
+… the `"panic_abort"` feature enables the [`replace_with_or_abort_unchecked()`](https://docs.rs/replace_with/0.1.2/replace_with/fn.replace_with_or_abort_unchecked.html) function becomes on stable Rust as an `unsafe` function, a simple wrapper around `ptr::write(dest, f(ptr::read(dest)));`.
+
+**Word of caution:** It is crucial to only ever use this function having defined `panic = "abort"`, or else bad things may happen. It's *up to you* to uphold this invariant!
+
 ## License
 Licensed under either of
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ impl States {
 
 Huzzah!
 
+## `no_std`
+
+To use `replace_with` with `no_std` you have to disable the `std` feature, which is active by default, by specifying your dependency to it like this:
+
+```toml
+// Cargo.toml
+
+[dependencies.replace_with]
+version = ...
+default-features = false
+features = []
+...
+```
+
+The [`replace_with()`](https://docs.rs/replace_with/0.1.2/replace_with/fn.replace_with.html) & [`replace_with_or_default()`](https://docs.rs/replace_with/0.1.2/replace_with/fn.replace_with_or_default.html) functions are available on stable Rust both, with and without `std`.
+
+The [`replace_with_or_abort()`](https://docs.rs/replace_with/0.1.2/replace_with/fn.replace_with_or_abort.html) function however by default makes use of [`std::process::abort()`](https://doc.rust-lang.org/std/process/fn.abort.html) which is not available with `no_std`.
+
+As such `replace_with` will by default call [`core::intrinsics::abort()`](https://doc.rust-lang.org/core/intrinsics/fn.abort.html) instead, which in turn requires nightly Rust.
+
 ## License
 Licensed under either of
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Huzzah!
 To use `replace_with` with `no_std` you have to disable the `std` feature, which is active by default, by specifying your dependency to it like this:
 
 ```toml
-// Cargo.toml
+# Cargo.toml
 
 [dependencies.replace_with]
 version = ...
@@ -83,7 +83,7 @@ Not everything is lost for stable `no_std` though, `replace_with` has one more t
 If you define [`panic = abort`](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/aborting-on-panic.html) in the `[profile]` section of your crate's `Cargo.toml` …
 
 ```toml
-// Cargo.toml
+# Cargo.toml
 
 [profile.debug]
 panic = "abort"
@@ -95,7 +95,7 @@ panic = "abort"
 … and add the `"panic_abort"` feature to `replace_with` in the `dependencies` section of your crate's `Cargo.toml` …
 
 ```toml
-// Cargo.toml
+# Cargo.toml
 
 [dependencies.replace_with]
 features = ["panic_abort"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,65 @@ pub fn replace_with_or_abort<T, F: FnOnce(T) -> T>(dest: &mut T, f: F) {
 	replace_with(dest, || unsafe { std::intrinsics::abort() }, f);
 }
 
+/// Temporarily takes ownership of a value at a mutable location, and replace it with a new value
+/// based on the old one. Aborts on panic.
+///
+/// We move out of the reference temporarily, to apply a closure `f`, returning a new value, which
+/// is then placed at the original value's location.
+///
+/// # An important note
+///
+/// On panic (or to be more precise, unwinding) of the closure `f`, the process will **abort** to
+/// avoid returning control while `dest` is in a potentially invalid state.
+///
+/// Unlike for `replace_with_or_abort()` users of `replace_with_or_abort_unchecked()` are expected
+/// to have `features = ["panic_abort", …]` defined in `Cargo.toml`
+/// and `panic = "abort"` defined in their profile for it to behave semantically correct:
+///
+/// ```toml
+/// // Cargo.toml
+///
+/// [profile.debug]
+/// panic = "abort"
+///
+/// [profile.release]
+/// panic = "abort"
+/// ```
+///
+/// **Word of caution:** It is crucial to only ever use this function having defined `panic = "abort"`,
+/// or else bad things may happen. It's *up to you* to uphold this invariant!
+///
+/// If this behaviour is undesirable, use [replace_with] or [replace_with_or_default].
+///
+/// Equivalent to `replace_with(dest, || process::abort(), f)`.
+///
+/// # Example
+///
+/// ```
+/// # use replace_with::*;
+/// enum States {
+/// 	A(String),
+/// 	B(String),
+/// }
+///
+/// impl States {
+/// 	fn poll(&mut self) {
+/// 		unsafe {
+/// 			replace_with_or_abort_unchecked(self, |self_| match self_ {
+/// 				States::A(a) => States::B(a),
+///	 				States::B(a) => States::A(a),
+/// 			});
+/// 		}
+/// 	}
+/// }
+/// ```
+///
+#[inline]
+#[cfg(feature = "panic_abort")]
+pub unsafe fn replace_with_or_abort_unchecked<T, F: FnOnce(T) -> T>(dest: &mut T, f: F) {
+	ptr::write(dest, f(ptr::read(dest)));
+}
+
 #[cfg(test)]
 mod test {
 	// These functions copied from https://github.com/Sgeo/take_mut/blob/1bd70d842c6febcd16ec1fe3a954a84032b89f52/src/lib.rs#L102-L147

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub fn replace_with_or_abort<T, F: FnOnce(T) -> T>(dest: &mut T, f: F) {
 /// and `panic = "abort"` defined in their profile for it to behave semantically correct:
 ///
 /// ```toml
-/// // Cargo.toml
+/// # Cargo.toml
 ///
 /// [profile.debug]
 /// panic = "abort"


### PR DESCRIPTION
This PR does three things:

1. It makes `fn replace_with()` & `fn replace_with_or_default()` available on both stable and nightly Rust with `no_std`.
2. It makes `fn replace_with_or_abort()` available on nightly Rust with `no_std` via `"nightly"` feature.
3. It makes `unsafe fn replace_with_or_abort_unchecked()` available via `"panic_abort"` feature.

The latter expects `panic = "abort"` to be defined in `Cargo.toml`. Being hidden behind a feature flag it will also be hidden on docs.rs (afaik), which I would consider desirable, actually. It's a "last resort" escape hatch, not an API one would want to get into everybody's hands, without knowing the issues around unwinding.

I chose the `unsafe fn …_unchecked()` naming pattern, as it's a [quite common pattern](https://doc.rust-lang.org/std/?search=_unchecked) already.