### PR TITLE
Replace mem::forget with ManuallyDrop, fixing UB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replace_with"
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["rust-patterns"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 	all(not(feature = "std"), feature = "nightly"),
 	feature(core_intrinsics)
 )]
-#![doc(html_root_url = "https://docs.rs/replace_with/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/replace_with/0.1.7")]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,8 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
 pub fn on_unwind<F: FnOnce() -> T, T, P: FnOnce()>(f: F, p: P) -> T {
 	let x = OnDrop(mem::ManuallyDrop::new(p));
 	let t = f();
-	let _ = unsafe { ptr::read(&*x.0) };
-	mem::forget(x);
+	let mut x = mem::ManuallyDrop::new(x);
+	unsafe { mem::ManuallyDrop::drop(&mut x.0) };
 	t
 }
 


### PR DESCRIPTION
As shown in https://github.com/rust-lang/miri/issues/1508, it was possible to "find UB" in `replace_with` with Miri.

~~I also changed the `ptr::read` from the existing `ManuallyDrop` into a more straight-forward `ManuallyDrop::take`.~~