### PR TITLE
Remove `std` feature flag from `replace_with_or_abort_and_return_unchecked`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,7 +473,6 @@ pub fn replace_with_or_abort_and_return<T, U, F: FnOnce(T) -> (U, T)>(dest: &mut
 /// }
 /// ```
 #[inline]
-#[cfg(feature = "std")]
 #[cfg(feature = "panic_abort")]
 pub unsafe fn replace_with_or_abort_and_return_unchecked<T, U, F: FnOnce(T) -> (U, T)>(
 	dest: &mut T, f: F,


### PR DESCRIPTION
AFAICT, this function doesn't have any additional requirements beyond `replace_with_or_abort_unchecked`, which does not require `std`, so this should be OK to remove.